### PR TITLE
Updated configuration-github to match current home directory

### DIFF
--- a/docs/configuration-github.md
+++ b/docs/configuration-github.md
@@ -61,4 +61,4 @@ Renovate Pro requires configuration via environment variables in addition to Ren
 
 The core Renovate OSS functionality can be configured using environment variables (e.g. `RENOVATE_XXXXXX`) or via a `config.js` file that you mount inside the Renovate Pro container to `/usr/src/app/config.js`.
 
-**npm Registry** If using your own npm registry, you may find it easiest to update your `docker-compose.yml` to include a volume that maps an `.npmrc` file to `/home/node/.npmrc`. The RC file should contain `registry=...` with the registry URL your company uses internally. This will allow Renovate to find shared configs and other internally published packages.
+**npm Registry** If using your own npm registry, you may find it easiest to update your `docker-compose.yml` to include a volume that maps an `.npmrc` file to `/home/ubuntu/.npmrc`. The RC file should contain `registry=...` with the registry URL your company uses internally. This will allow Renovate to find shared configs and other internally published packages.


### PR DESCRIPTION
It looks like the `.npmrc` file should go into `/home/ubuntu/` instead of `/home/node/`.