### PR TITLE
v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.16.0 - 2019-06-??
+## 0.16.0 - 2019-07-14
 
 This feature release updates the base from `renovate@14.23.0` to `renovate@18.16.3`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.16.0 - 2019-05-??
+## 0.16.0 - 2019-06-??
 
+This feature release updates the base from `renovate@16.10.6` to `renovate@18.16.3`.
 
+### Build changes
+
+The `renovate/pro` image now uses `renovate/renovate` as its base image, meaning that you can determine exactly which binary files come preinstalled by looking at the [corresponding Renovate OSS Dockerfile](https://github.com/renovatebot/renovate/blob/2f2c0736f67414a2d2fc0b129ca95dfc41bf0289/Dockerfile).
+
+A second important change is that Renovate Pro now uses `git` under the hood for all file system queries. Renovate Pro performs a shallow clone each run like a CI system typically does, and having the full repo locally also enables some advanced features such as Go Modules vendoring.
+
+### New Package Managers
+
+- **clojure:** Add basic support for Leiningen and `deps.edn` ([#3685](https://github.com/renovatebot/renovate/issues/3685)) ([bda25d6](https://github.com/renovatebot/renovate/commit/bda25d6))
+
+### New Features
+
+- Node.js: Dynamically determine LTS versions by date
+- Host Rules: Allow different rules based on full endpoint prefix
+- Configurable timeouts per-host
+- Use GraphQL to optimize issue list retrieval
+- Better displayFrom/displayTo logic for Pull Request displays
+- Provide npm diff links via renovatebot.com
+- Add `commitBodyTable` option to append a table of all upgrades to a commit message body
+- Pipenv: support index registry URLs
+- Support scheduling by weeks of year
+- Lock file maintenance for Composer
+
+### Bug fixes
+
+- Default 60s timeout for all requests to avoid potentially hanging forever
+- Rebase branch if package file not found in existing branch
+- Maven: isVersion/isSingleVersion/isValid correction
+- PIP: detect lockedVersion when extracting
+- Docker: handle host with port correctly
+- gitFs: run checkout/reset when setting base branch
 
 ## 0.15.3 - 2019-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.16.0 - 2019-06-??
 
-This feature release updates the base from `renovate@16.10.6` to `renovate@18.16.3`.
+This feature release updates the base from `renovate@14.23.0` to `renovate@18.16.3`.
 
 ### Build changes
 
@@ -17,10 +17,27 @@ A second important change is that Renovate Pro now uses `git` under the hood for
 
 ### New Package Managers
 
-- **clojure:** Add basic support for Leiningen and `deps.edn` ([#3685](https://github.com/renovatebot/renovate/issues/3685)) ([bda25d6](https://github.com/renovatebot/renovate/commit/bda25d6))
+- **Maven:**: Supported added for `pom.xml` parsing, including ranges
+- **Cargo**: Rust's package manager support
+- **Poetry**: An alternative Python package manager
+- **Ruby-version**: Update `.ruby-version` files
+- **Dart**: Add support for package manager
+- **Scala**: sbt support
+- **Homebrew**: Add support for keeping homebrew definitions up to date
+- **Clojure:** Add basic support for Leiningen and `deps.edn` ([#3685](https://github.com/renovatebot/renovate/issues/3685)) ([bda25d6](https://github.com/renovatebot/renovate/commit/bda25d6))
 
 ### New Features
 
+- Nuget: Support authenticated feeds
+- Bazel: Support `git_repository` commit hashes, use commit / tag combo for `go_repository`
+- Bazel: Support commit-based `http_archive`
+- `postUpdateOptions`: npm and yarn deduplication opt-in
+- `packageRules`: support `baseBranchList` and `datasources` selectors
+- Make `parentDir`, `baseDir` metadata available to templates
+- Bazel: expand support to non-WORKSPACE files
+- Bazel: support "container_pull" dependency-type
+- npm package aliases
+- Go Modules vendoring
 - Node.js: Dynamically determine LTS versions by date
 - Host Rules: Allow different rules based on full endpoint prefix
 - Configurable timeouts per-host
@@ -34,12 +51,18 @@ A second important change is that Renovate Pro now uses `git` under the hood for
 
 ### Bug fixes
 
+- lerna: call bootstrap if yarn workspaces not used
+- npm: don’t set skipInstalls when file refs found
+- run glob matching with dotfile matching enabled
+- Nuget: opt in to semver 2.0.0 and prereleases
 - Default 60s timeout for all requests to avoid potentially hanging forever
 - Rebase branch if package file not found in existing branch
 - Maven: isVersion/isSingleVersion/isValid correction
 - PIP: detect lockedVersion when extracting
 - Docker: handle host with port correctly
 - gitFs: run checkout/reset when setting base branch
+- Go modules: detect gopkg.in major bumps
+- Master Issue add link to edited PRs
 
 ## 0.15.3 - 2019-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.0 - 2019-05-??
+
+
+
 ## 0.15.3 - 2019-03-07
 
 This patch fixes two issues:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.16.0 - 2019-07-14
 
-This feature release updates the base from `renovate@14.23.0` to `renovate@18.16.3`.
+This feature release updates the base from `renovate@14.23.0` to `renovate@18.16.11`.
 
 ### Build changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ A second important change is that Renovate Pro now uses `git` under the hood for
 
 ### New Package Managers
 
-- **Maven:**: Supported added for `pom.xml` parsing, including ranges
-- **Cargo**: Rust's package manager support
+- **Maven**: Supported added for `pom.xml` parsing, including ranges
+- **Pipenv**: Pipfile and lock file updating now enabled
 - **Poetry**: An alternative Python package manager
 - **Ruby-version**: Update `.ruby-version` files
 - **Dart**: Add support for package manager

--- a/examples/docker-compose-ghe.yml
+++ b/examples/docker-compose-ghe.yml
@@ -10,7 +10,7 @@ services:
       - ./postgres-data:/var/lib/postgresql/data
   # Renovate Pro runs as a single long-lived server
   server:
-    image: renovate/pro:0.15.3
+    image: renovate/pro:0.16.0
     restart: on-failure
     depends_on:
       - db

--- a/examples/docker-compose-gitlab.yml
+++ b/examples/docker-compose-gitlab.yml
@@ -10,7 +10,7 @@ services:
       - ./postgres-data:/var/lib/postgresql/data
   # Renovate Pro runs as a single long-lived server
   server:
-    image: renovate/pro:0.15.3
+    image: renovate/pro:0.16.0
     restart: on-failure
     depends_on:
       - db


### PR DESCRIPTION
- [x] Update to latest Renovate OSS core
- [x] Document features and fixes from core
- [x] Check existing 0.15.x branch for any commits to be merged
- [x] Write document on file location changes
- [x] Fix GitLab onboarding webhook logic