### PR TITLE
Fix Security alerts label

### DIFF
--- a/docs/configuration-github.md
+++ b/docs/configuration-github.md
@@ -12,7 +12,7 @@ The App requires the following permissions if available:
 - Issues: Read & write
 - Repository metadata: Read-only
 - Pull Requests: Read & write
-- Security vulnerability alerts: Read-only (if available)
+- Security alerts: Read-only (if available)
 - Commit statuses: Read & write
 
 The App should also subscribe to the following webhook events:


### PR DESCRIPTION
`Security vulnerability alerts` is known as `Security alerts` in the GitHub Apps creation form. 

![image](https://user-images.githubusercontent.com/8191198/73469709-19c1d200-4387-11ea-9651-5ce67f1fc519.png)
