### PR TITLE
docs: assigning team reviewers requires organization read access

### DIFF
--- a/docs/configuration-github.md
+++ b/docs/configuration-github.md
@@ -14,6 +14,7 @@ The App requires the following permissions if available:
 - Pull Requests: Read & write
 - Security alerts: Read-only (if available)
 - Commit statuses: Read & write
+- Organization members: Read (if available)
 
 The App should also subscribe to the following webhook events:
 


### PR DESCRIPTION
For Github Entreprise you must give read permission to Organization members

The following configuration in `renovate.json` to work on GHE on perm

```json
{
  "reviewers": [
    "team:my-team"
  ],
}
```

Otherwise the following error occurs:
```json
"err": {
  "message": "platform-failure",
  "stack": "Error: platform-failure\n    at get (/usr/src/app/node_modules/renovate/dist/platform/github/gh-got-wrapper.js:131:19)\n    at process._tickCallback (internal/process/next_tick.js:68:7)"
}
```

I had to hack `gh-got-wrapper.js` on the docker image renovate/pro:0.18.5 with a  `logger_1.logger.info({ err }, "WTF renovate")` in order to find the error from github

```json
{
// ...
  "body": {
    "message": "Validation Failed",
    "errors": [
      "Could not resolve to a node with the global id of 'MDQ6VGVhbTEwMQ=='."
    ],
    "documentation_url": "https://developer.github.com/enterprise/2.18/v3/pulls/review_requests/#create-a-review-request"
  },
  "message": "Response code 422 (Unprocessable Entity)",
  "stack": "HTTPError: Response code 422 (Unprocessable Entity)\n    at EventEmitter.emitter.on (/usr/src/app/node_modules/got/source/as-promise.js:74:19)\n    at process._tickCallback (internal/process/next_tick.js:68:7)"
// ...
}
```