### PR TITLE
(fix/charts): Give configmap correct name

### DIFF
--- a/helm-charts/mend-renovate-ce/templates/configmap.yaml
+++ b/helm-charts/mend-renovate-ce/templates/configmap.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-config-js
+  name: {{ include "mend-renovate.fullname" . }}-config-js
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "mend-renovate.name" . }}
     helm.sh/chart: {{ include "mend-renovate.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -372,7 +372,7 @@ spec:
       volumes:
         - name: {{ .Release.Name }}-config-js-volume
           configMap:
-            name: {{ .Release.Name }}-config-js
+            name: {{ include "mend-renovate.fullname" . }}-config-js
         {{- if or .Values.renovate.npmrc .Values.renovate.npmrcExistingSecret }}
         - name: {{ .Release.Name }}-npmrc-volume
           secret:

--- a/helm-charts/mend-renovate-ee/templates/configmap.yaml
+++ b/helm-charts/mend-renovate-ee/templates/configmap.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-config-js
+  name: {{ include "mend-renovate.fullname" . }}-config-js
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "mend-renovate.name" . }}
     helm.sh/chart: {{ include "mend-renovate.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/worker-deployment.yaml
@@ -215,7 +215,7 @@ spec:
       volumes:
         - name: {{ .Release.Name }}-config-js-volume
           configMap:
-            name: {{ .Release.Name }}-config-js
+            name: {{ include "mend-renovate.fullname" . }}-config-js
         {{- if or .Values.renovateWorker.npmrc .Values.renovateWorker.npmrcExistingSecret }}
         - name: {{ .Release.Name }}-npmrc-volume
           secret:


### PR DESCRIPTION
The configmap name should reflect the full deployed chart name, matching other templated objects e.g the pvc and deployment. In a namespace with many charts deployed, it is otherwise not easily identifiable as from renovate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated naming conventions for ConfigMap resources and labels in Helm charts to use standardized helper functions, ensuring consistency across deployments.
  * Adjusted volume references in deployment templates to align with the new naming scheme.

No changes to functionality or user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->