### PR TITLE
fix(docs): Update MEND_RNV_MC_TOKEN default value

### DIFF
--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -50,7 +50,7 @@ Environment variables for the **Mend Renovate Enterprise Worker** are in the nex
 >
 > For an Enterprise license key, contact Mend at http://mend.io.
 
-**`MEND_RNV_MC_TOKEN`**: [Enterprise only] The authentication token required when using Merge Confidence Workflows. Set this to 'auto', or provide the value of a merge confidence API token. (default is `off`)
+**`MEND_RNV_MC_TOKEN`**: [Enterprise only] The authentication token required when using Merge Confidence Workflows. Set this to 'auto', or provide the value of a merge confidence API token. (defaults to `off`)
 
 ### Connection to the Source Code Management (SCM)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies that `MEND_RNV_MC_TOKEN` defaults to `off` and updates its description in `docs/configuration-options.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4193357410f209593eb36411aae7978c30711f41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified the configuration option MEND_RNV_MC_TOKEN: explicitly notes the default is “off.”
  - Retained guidance on setting the value to “auto” or supplying a Merge Confidence API token.
  - Improved explanatory text for Enterprise users to better understand configuration behavior.
  - No behavioral changes to the application; this update affects documentation only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->