### PR TITLE
chore(renovate): use `bumpVersions` for Helm charts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,31 @@
       "ghcr.io/mend/renovate-ee-worker"
     ],
     "versioning": "docker",
-    "automerge": true
+    "automerge": true,
+    "bumpVersions": [
+      {
+        "description": "Bump the `version` for the Helm charts, in line with the version bump from the Docker image",
+        "filePatterns": [
+          "helm-charts/mend-renovate-ce/Chart.yaml",
+          "helm-charts/mend-renovate-ee/Chart.yaml"
+        ],
+        "matchStrings": [
+          "version:\\s(?<version>[^\\s]+)"
+        ],
+        "bumpType": "{{updateType}}"
+      },
+      {
+        "description": "Bump the `appVersion` for the Helm charts, in line with the version bump from the Docker image",
+        "filePatterns": [
+          "helm-charts/mend-renovate-ce/Chart.yaml",
+          "helm-charts/mend-renovate-ee/Chart.yaml"
+        ],
+        "matchStrings": [
+          "appVersion:\\s(?<version>[^\\s]+)"
+        ],
+        "bumpType": "{{updateType}}"
+      }
+    ]
   }],
   "ignorePaths": []
 }


### PR DESCRIPTION
Via [0][1], and noted in #764, we should automagically be bumping the
Helm `appVersion` and `version` accordingly.

We can be slightly lazy about the `bumpType` by using the existing
`updateType`.

These appear to be two separate rules, rather than a combined rule.

[0]: https://docs.renovatebot.com/configuration-options/#bumpversions
[1]: https://secustor.dev/blog/renovate_generic_version_bump/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Renovate bumpVersions rules to auto-bump Helm charts' version and appVersion when Mend Renovate Docker images update.
> 
> - **Renovate config (`renovate.json`)**:
>   - Add `bumpVersions` rules scoped to Mend Renovate Docker images (`ghcr.io/mend/renovate-*`, versioning `docker`).
>     - Auto-bump Helm chart `version` in `helm-charts/mend-renovate-ce/Chart.yaml` and `helm-charts/mend-renovate-ee/Chart.yaml` via `matchStrings: version: (?<version>...)` using `bumpType: {{updateType}}`.
>     - Auto-bump Helm chart `appVersion` in the same files via `matchStrings: appVersion: (?<version>...)` using `bumpType: {{updateType}}`.
>   - Keep `automerge: true` for the grouped Mend Renovate image updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22a70d2b4b4085f292c115fe9d413a5cb79cc203. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to enhance Helm chart dependency version management with automated version bump rules for Chart.yaml files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->