### PR TITLE
docs(metrics): document custom Prometheus metrics

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -34,6 +34,102 @@ This endpoint exposes Prometheus-compatible metrics.
 
 Controlled by `MEND_RNV_API_ENABLE_PROMETHEUS_METRICS` (backward compatible with `MEND_RNV_PROMETHEUS_METRICS_ENABLED`)
 
+A number of default metrics are exposed by Node.JS.
+
+Additionally, the following custom metrics are exposed:
+
+<table>
+  <thead>
+    <tr>
+      <th>Metric</th>
+      <th>Type</th>
+      <th>Description</th>
+      <th>Comments</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>mend_renovate_queue_size</code>
+      </td>
+      <td>
+        <code>gauge</code>
+      </td>
+      <td>
+        Current size of various queue types.
+      </td>
+      <td>
+        Contains a number of queue types:
+        <!-- don't indent further or add a newline above this line, as Markdown rendering will make it a code block -->
+        <ul>
+          <li>
+            <code>scheduledAll</code>
+          </li>
+          <li>
+            <code>scheduledHot</code>
+          </li>
+          <li>
+            <code>scheduledCold</code>
+          </li>
+          <li>
+            <code>scheduledCapped</code>
+          </li>
+          <li>
+            <code>requested</code>
+          </li>
+        </ul>
+        <!-- don't indent further -->
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>mend_renovate_queue_max_wait</code>
+      </td>
+      <td>
+        <code>gauge</code>
+      </td>
+      <td>
+        Current age in seconds of the oldest entry in each queue type.
+      </td>
+      <td>
+        Contains a number of queue types:
+        <!-- don't indent further or add a newline above this line, as Markdown rendering will make it a code block -->
+        <ul>
+          <li>
+            <code>scheduledAll</code>
+          </li>
+          <li>
+            <code>scheduledHot</code>
+          </li>
+          <li>
+            <code>scheduledCold</code>
+          </li>
+          <li>
+            <code>scheduledCapped</code>
+          </li>
+          <li>
+            <code>requested</code>
+          </li>
+        </ul>
+        <!-- don't indent further -->
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>mend_renovate_job_wait_time</code>
+      </td>
+      <td>
+        <code>summary</code>
+      </td>
+      <td>
+        Total time taken for a job from being enqueued to execution.
+      </td>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ### System API Routes
 
 ```


### PR DESCRIPTION
This builds on top of the work done in CE/EE 8.1 to add the Prometheus
metrics, adding documentation for the additional metrics we currently
expose.

This has to be via an HTML table due to needing to add a list to the
comments.

Closes #221.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents exposed Prometheus metrics in docs/api.md, adding details for queue size/max-wait gauges and job wait-time summary.
> 
> - **Docs**:
>   - **Prometheus metrics in `docs/api.md`**:
>     - Note that default Node.js metrics are exposed.
>     - Document custom metrics:
>       - `mend_renovate_queue_size` (gauge) — current size per queue type (`scheduledAll`, `scheduledHot`, `scheduledCold`, `scheduledCapped`, `requested`).
>       - `mend_renovate_queue_max_wait` (gauge) — age of oldest entry per queue type.
>       - `mend_renovate_job_wait_time` (summary) — enqueue-to-execution duration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48b9d69899ea87ba6b79b8ef656fb18d1ea138db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Prometheus metrics documentation, including three custom queue-related metrics with detailed descriptions, types, and queue category breakdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->