### PR TITLE
docs: Remove beta label from Bitbucket Data Center

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ The following platforms are supported by Mend Renovate Community Edition and Ent
 - GitHub Enterprise Server
 - GitLab Cloud
 - GitLab Enterprise Edition
-- Bitbucket Data Center (in beta)
+- Bitbucket Data Center
 
 ## Documentation contents
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the "in beta" label for Bitbucket Data Center in the supported platforms list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57b077152e1afe429e9bfede974290ea036b6cb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Beta Disclaimer was removed previously on [Dec 22, 2023](https://github.com/mend/renovate-ce-ee/commit/5168929b59690a35d445b2c06f01ec55ece0314f)

* **Documentation**
  * Bitbucket Data Center is now officially supported (removed beta designation).


<!-- end of auto-generated comment: release notes by coderabbit.ai -->