### PR TITLE
docs: Add note on Automatic gitlab webhook creation

### DIFF
--- a/docs/setup-for-gitlab.md
+++ b/docs/setup-for-gitlab.md
@@ -60,7 +60,13 @@ You can enable webhooks on your GitLab repos manually, or with automation.
 
 #### Option: Automatic webhook creation
 
-When enabled, will automatically install webhooks for all repos that are enabled with Renovate. Attempts are made to remove webhooks when repos are uninstalled.
+When enabled, will automatically install webhooks for all new repos that are enabled with Renovate. Attempts are made to remove webhooks when repos are uninstalled.
+
+> [!NOTE]
+>
+> Currently, if you add the configuration for Webhooks later to an existing setup, webhooks will not be added to repositories already registered in Renovates DB.
+>
+> As a workaround, you can uninstall and reinstall repos that you want to add webhooks to. Alternatively, if you delete the database, all repos will be freshly re-installed and webhooks will be created for them. ([Issue #762](https://github.com/mend/renovate-ce-ee/issues/762))
 
 Webhook installation requires an admin user account that has `Maintainer` access to the repos.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies that automatic GitLab webhooks are created only for new enabled repos and documents limitations for existing repos with suggested workarounds.
> 
> - **Docs (GitLab setup)**:
>   - Clarify automatic webhook creation: installed only for new repos enabled with Renovate.
>   - Add note on limitation for existing repos already in Renovate DB and provide workarounds (reinstall repos or reset DB).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e151ace26e5d413a821ff8353517fa7740cd728. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified GitLab setup: automatic webhook creation now applies only to newly enabled repositories.
  * Added a prominent note that enabling Webhooks later will not add webhooks to repositories already registered.
  * Documented workaround options for existing setups (reinstall repositories or reset registration data).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->