### PR TITLE
chore(renovate): ensure all CE/EE versions bump together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
       "ghcr.io/mend/renovate-ee-server",
       "ghcr.io/mend/renovate-ee-worker"
     ],
+    "minimumGroupSize": 3,
     "versioning": "docker",
     "automerge": true,
     "bumpVersions": [


### PR DESCRIPTION
As noted in [0], we're periodically seeing cases where only 2 of the 3
images are bumped in one go (likely due to caching).

Instead, we can require that the group is not created until all 3 of the
updates exist.

[0]: https://github.com/renovatebot/renovate/discussions/39353

