### PR TITLE
fix(enterprise): automagically wire in Merge Confidence token

### DIFF
--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -159,8 +159,8 @@ renovateServer:
   # Optional: defines the endpoint used to retrieve Merge Confidence data by querying this API.
   mendRnvMergeConfidenceEndpoint:
 
-  # Optional: Set to 'auto' to enable automatic token generation. Defaults to off
-  mendRnvMergeConfidenceToken:
+  # enable automatic token generation. Can also be set to 'off'
+  mendRnvMergeConfidenceToken: 'auto'
 
   # Optional. Format: s3://bucket/dir1/dir2. Defines S3 storage location for saving job logs
   mendRnvLogHistoryS3:


### PR DESCRIPTION
Instead of needing to explicitly enable this, Enterprise customers
should have this as a default, as it eases the onboarding process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration to enable automatic merge confidence token generation in Helm deployments. Users can disable this feature by adjusting configuration settings if needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->