### PR TITLE
feat(helm): enable RBAC

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -8,7 +8,7 @@ For example, when enabled, this would allow a user to send a GitHub Personal Acc
 
 ## How to enable
 
-To enable RBAC on your Mend Renovate Self-Hosted deployment, you will need to specify `env MEND_RNV_SERVER_RBAC_ENABLED=true`.
+To enable RBAC on your Mend Renovate Self-Hosted deployment, you will need to specify `env MEND_RNV_SERVER_RBAC_ENABLED=true`, or `mendRnvServerRbacEnabled` in the Helm chart.
 
 The RBAC functionality is available for both Community Edition and Enterprise Edition. See the platform support below.
 

--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -338,6 +338,10 @@ spec:
             - name: MEND_RNV_SERVER_HTTPS_CONFIG_PATH
               value: {{ .Values.renovate.mendRnvServerHttpsConfigPath | quote}}
             {{- end }}
+            {{- if .Values.renovate.mendRnvServerRbacEnabled }}
+            - name: MEND_RNV_SERVER_RBAC_ENABLED
+              value: {{ .Values.renovate.mendRnvServerRbacEnabled| quote}}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/helm-charts/mend-renovate-ce/values.yaml
+++ b/helm-charts/mend-renovate-ce/values.yaml
@@ -204,6 +204,15 @@ renovate:
   # Path to the TLS server config.
   mendRnvServerHttpsConfigPath:
 
+  # Enable Role Based Access Control, to allow users to provide platform-specific authentication (such as Personal Access Tokens) to authenticate to the APIs.
+  #
+  # NOTE: this only supports certain platforms.
+  #
+  # See also: https://github.com/mend/renovate-ce-ee/blob/HEAD/docs/rbac.md
+  #
+  # Optional. Set to 'true' to enable.
+  mendRnvServerRbacEnabled:
+
   # Self-hosted renovate configuration file, will be mounted as a config map
   config: |
     module.exports = {

--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -312,6 +312,10 @@ spec:
             - name: MEND_RNV_ENABLE_HTTP2
               value: {{ .Values.renovateServer.mendRnvEnableHttp2 | quote }}
             {{- end }}
+            {{- if .Values.renovateServer.mendRnvServerRbacEnabled }}
+            - name: MEND_RNV_SERVER_RBAC_ENABLED
+              value: {{ .Values.renovateServer.mendRnvServerRbacEnabled| quote}}
+            {{- end }}
           ports:
             - name: ee-server
               containerPort: 8080

--- a/helm-charts/mend-renovate-ee/values.yaml
+++ b/helm-charts/mend-renovate-ee/values.yaml
@@ -221,6 +221,15 @@ renovateServer:
   # Path to the TLS server config.
   mendRnvServerHttpsConfigPath:
 
+  # Enable Role Based Access Control, to allow users to provide platform-specific authentication (such as Personal Access Tokens) to authenticate to the APIs.
+  #
+  # NOTE: this only supports certain platforms.
+  #
+  # See also: https://github.com/mend/renovate-ce-ee/blob/HEAD/docs/rbac.md
+  #
+  # Optional. Set to 'true' to enable.
+  mendRnvServerRbacEnabled:
+
   # Set log level, defaults to 'info'. Allowed values: fatal, error, warn, info, debug, trace
   logLevel: info
   # Set log format, defaults to pretty format. Allowed values: undefined or 'json'


### PR DESCRIPTION
Role based access control has been available for users, but we haven't
yet wired it in for Helm deployments.

Now we have documented that RBAC exists, we should also make it possible
to enable it via Helm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Role-Based Access Control (RBAC) support for Community and Enterprise deployments.
  * RBAC can be enabled via an environment variable or via Helm chart configuration values.

* **Documentation**
  * Updated RBAC docs with instructions and configuration guidance for enabling RBAC across deployment types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm/template and documentation-only change that gates behavior behind an optional value; no core runtime logic changes.
> 
> **Overview**
> Helm deployments can now enable RBAC via a new chart value (`mendRnvServerRbacEnabled`), which conditionally injects `MEND_RNV_SERVER_RBAC_ENABLED` into the CE `deployment.yaml` and EE `server-deployment.yaml`.
> 
> Documentation is updated to mention Helm-based enablement alongside the existing env-var approach (`docs/rbac.md`), and both charts’ `values.yaml` files document the new optional setting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d1931925ebbb1484a5f6625539f7b2ce85dee6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->