### PR TITLE
docs(prometheus): clarify the default metrics are Server-only

### DIFF
--- a/docs/prometheus-metrics.md
+++ b/docs/prometheus-metrics.md
@@ -1,6 +1,6 @@
 # Prometheus metrics
 
-A number of default metrics are exposed by Node.JS.
+A number of default metrics are exposed by Node.JS for the Mend Renovate Self-Hosted Server respondng to the API request, _not_ the worker(s)
 
 Additionally, the following custom metrics are exposed:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that default Node.JS metrics pertain to the Renovate Self-Hosted Server responding to API requests, not the worker processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->