### PR TITLE
docs(rbac): update default cache settings

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -19,14 +19,14 @@ The RBAC functionality is available for both Community Edition and Enterprise Ed
 
 ## Caching
 
-By default, once a user's permissions are looked up, they are cached for 60 minutes (1 hour).
+By default, once a user's permissions are looked up, they are cached for 5 minutes.
 
 You can configure this using `MEND_RNV_CACHE_TTL_OVERRIDES_MAP`.
 
-For instance, to configure the RBAC data be cached for a maximum of 5 minutes:
+For instance, to configure the RBAC data be cached for a maximum of 15 minutes:
 
 ```sh
-export MEND_RNV_CACHE_TTL_OVERRIDES_MAP=rbac=5m
+export MEND_RNV_CACHE_TTL_OVERRIDES_MAP=rbac=15m
 ```
 
 ## Supported APIs


### PR DESCRIPTION
As they're changed as of 14.0.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated RBAC caching default time-to-live (TTL) from 60 minutes to 5 minutes for improved cache freshness.
  * Updated example TTL override configuration to 15 minutes.
  * Refreshed configuration examples to reflect the new caching defaults and override values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->