### PR TITLE
docs(openapi): update for 14.0.0

### DIFF
--- a/docs/openapi-community.yaml
+++ b/docs/openapi-community.yaml
@@ -27,7 +27,7 @@ tags:
 
       - On the Workers:
         - `RENOVATE_REPOSITORY_CACHE=enabled`
-        - If using the S3 repo cache, `RENOVATE_X_REPO_CACHE_FORCE_LOCAL=true` must be set
+        - If using the S3 repo cache, `RENOVATE_REPOSITORY_CACHE_FORCE_LOCAL=true` (prior to 14.0.0, `RENOVATE_X_REPO_CACHE_FORCE_LOCAL=true`) must be set
       - On the Server:
         - `MEND_RNV_CRON_LIBYEARS_MV_REFRESH` can be specified to override the cron schedule for updating org-level LibYears stats. The default is `20 * * * *` (every hour at 20 minutes past the hour)
   - name: Jobs
@@ -782,7 +782,7 @@ components:
 
         See [the Mend Renovate Self-Hosted RBAC docs](https://github.com/mend/renovate-ce-ee/blob/HEAD/docs/rbac.md) for more information.
 
-        Note that this permissions data is, by default, cached for 60m after first authorization.
+        Note that this permissions data is, by default, cached for 5m after first authorization.
       flows:
         password:
           tokenUrl: 'https://unused.example.com'
@@ -1353,6 +1353,11 @@ components:
           $ref: '#/components/schemas/JobsMeta'
         renovateVersion:
           type: string
+          pattern: '[0-9]+\.[0-9]+\.[0-9]+'
+          description: |
+            The exact Renovate CLI version used (as a Semantic Version).
+
+            This is the version of the Renovate CLI that is used when processing repositories.
         license:
           type: object
           additionalProperties: true
@@ -1985,7 +1990,7 @@ components:
       type: string
       format: date-time
       description: |
-        **Note**: this format will be corrected in the next breaking change.
+        **Note**: this format will be corrected in the 15.0.0 release.
 
         The date formats returned at this point in time are non-standard, and depend on the database used.
 

--- a/docs/openapi-enterprise.yaml
+++ b/docs/openapi-enterprise.yaml
@@ -27,7 +27,7 @@ tags:
 
       - On the Workers:
         - `RENOVATE_REPOSITORY_CACHE=enabled`
-        - If using the S3 repo cache, `RENOVATE_X_REPO_CACHE_FORCE_LOCAL=true` must be set
+        - If using the S3 repo cache, `RENOVATE_REPOSITORY_CACHE_FORCE_LOCAL=true` (prior to 14.0.0, `RENOVATE_X_REPO_CACHE_FORCE_LOCAL=true`) must be set
       - On the Server:
         - `MEND_RNV_CRON_LIBYEARS_MV_REFRESH` can be specified to override the cron schedule for updating org-level LibYears stats. The default is `20 * * * *` (every hour at 20 minutes past the hour)
   - name: Jobs
@@ -805,7 +805,7 @@ paths:
         **NOTE** that this requires additional configuration in your deployment:
 
         - `RENOVATE_REPOSITORY_CACHE=enabled` must be set on Workers
-        - If using the S3 repo cache, `RENOVATE_X_REPO_CACHE_FORCE_LOCAL=true` must be set on Workers
+        - If using the S3 repo cache, `RENOVATE_REPOSITORY_CACHE_FORCE_LOCAL=true` (prior to 14.0.0, `RENOVATE_X_REPO_CACHE_FORCE_LOCAL=true`) must be set
       security:
         - serverApiSecret: []
         - githubRoleBasedAccessControl:
@@ -1000,7 +1000,7 @@ components:
 
         See [the Mend Renovate Self-Hosted RBAC docs](https://github.com/mend/renovate-ce-ee/blob/HEAD/docs/rbac.md) for more information.
 
-        Note that this permissions data is, by default, cached for 60m after first authorization.
+        Note that this permissions data is, by default, cached for 5m after first authorization.
       flows:
         password:
           tokenUrl: 'https://unused.example.com'
@@ -1571,6 +1571,11 @@ components:
           $ref: '#/components/schemas/JobsMeta'
         renovateVersion:
           type: string
+          pattern: '[0-9]+\.[0-9]+\.[0-9]+'
+          description: |
+            The exact Renovate CLI version used (as a Semantic Version).
+
+            This is the version of the Renovate CLI that is used when the Workers process repositories, as well as by background processes in the Server.
         license:
           type: object
           additionalProperties: true
@@ -2208,7 +2213,7 @@ components:
       type: string
       format: date-time
       description: |
-        **Note**: this format will be corrected in the next breaking change.
+        **Note**: this format will be corrected in the 15.0.0 release.
 
         The date formats returned at this point in time are non-standard, and depend on the database used.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced S3 repository cache environment variable guidance with clearer configuration instructions.
  * Reduced permissions caching duration from 60 to 5 minutes following initial authorization.
  * Improved Renovate CLI version tracking with validation patterns and enhanced documentation.
  * Updated date format references to the upcoming 15.0.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->