### PR TITLE
fix(helm): ensure `mendRnvLogHistoryCleanupCron` is quoted

### DIFF
--- a/helm-charts/mend-renovate-ce/Chart.yaml
+++ b/helm-charts/mend-renovate-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mend-renovate-ce
-version: 14.2.0
+version: 14.2.1
 appVersion: 14.2.0
 description: Mend Renovate Community Edition
 home: https://github.com/mend/renovate-ce-ee

--- a/helm-charts/mend-renovate-ce/templates/deployment.yaml
+++ b/helm-charts/mend-renovate-ce/templates/deployment.yaml
@@ -288,7 +288,7 @@ spec:
             {{- end }}
             {{- if .Values.renovate.mendRnvLogHistoryCleanupCron }}
             - name: MEND_RNV_LOG_HISTORY_CLEANUP_CRON
-              value: {{ .Values.renovate.mendRnvLogHistoryCleanupCron }}
+              value: {{ .Values.renovate.mendRnvLogHistoryCleanupCron | quote }}
             {{- end }}
             {{- if .Values.renovate.mendRnvForksProcessing }}
             - name: MEND_RENOVATE_FORKS_PROCESSING

--- a/helm-charts/mend-renovate-ee/Chart.yaml
+++ b/helm-charts/mend-renovate-ee/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mend-renovate-enterprise-edition
-version: 14.2.0
+version: 9.0.1
 appVersion: 14.2.0
 description: Mend Renovate Enterprise Edition
 home: https://github.com/mend/renovate-ce-ee

--- a/helm-charts/mend-renovate-ee/Chart.yaml
+++ b/helm-charts/mend-renovate-ee/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mend-renovate-enterprise-edition
-version: 9.0.0
+version: 14.2.0
 appVersion: 14.2.0
 description: Mend Renovate Enterprise Edition
 home: https://github.com/mend/renovate-ce-ee

--- a/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
+++ b/helm-charts/mend-renovate-ee/templates/server-deployment.yaml
@@ -247,7 +247,7 @@ spec:
             {{- end }}
             {{- if .Values.renovateServer.mendRnvLogHistoryCleanupCron }}
             - name: MEND_RNV_LOG_HISTORY_CLEANUP_CRON
-              value: {{ .Values.renovateServer.mendRnvLogHistoryCleanupCron }}
+              value: {{ .Values.renovateServer.mendRnvLogHistoryCleanupCron | quote }}
             {{- end }}
             {{- if .Values.renovateServer.mendRnvLibYearsMVRefreshCron }}
             - name: MEND_RNV_CRON_LIBYEARS_MV_REFRESH


### PR DESCRIPTION
  ## Summary
  - Add missing `| quote` to `mendRnvLogHistoryCleanupCron` in both CE and EE server deployment templates
  - Cron values containing `*` (e.g. `*/12 * * * *`) cause YAML parse errors when rendered without quoting

  ## Affected files 
  - `helm-charts/mend-renovate-ee/templates/server-deployment.yaml`
  - `helm-charts/mend-renovate-ce/templates/deployment.yaml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk templating change that only affects how the `MEND_RNV_LOG_HISTORY_CLEANUP_CRON` env var is rendered; main potential impact is changing the YAML output to a quoted string for cron expressions.
> 
> **Overview**
> Fixes Helm rendering for cron expressions by quoting `mendRnvLogHistoryCleanupCron` when templating the `MEND_RNV_LOG_HISTORY_CLEANUP_CRON` environment variable in both CE and EE deployment templates, preventing YAML parse errors for values containing `*`.
> 
> Also bumps the Enterprise Edition Helm chart version from `9.0.0` to `9.0.1` to reflect the packaging change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 745673732deb2a1a4d9f56a489fdc77b8a058a64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Render scheduling environment values as quoted strings in deployment templates for generated manifests.
  * Bumped the Enterprise Helm chart version to 9.0.1.
  * Bumped the Community Helm chart version to 14.2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->